### PR TITLE
Proposed alternate bindingConfig structure.

### DIFF
--- a/schema_syntax.json
+++ b/schema_syntax.json
@@ -11,17 +11,14 @@
             "sourceTemplate": "function_app.py", // template file where binding configuration is applied and job actions are performed on
             "bindingConfigurations": [
                 {
-                    "bindingType": "httpTrigger",
-                    "settings": [
-                        {
-                            "name": "authLevel",
-                            "replaces": "%$AuthLevelValue$%"
-                        },
-                        {
-                            "name": "route",
-                            "replaces": "%$route$%"
-                        }
-                    ]
+                    "placeholder": "%%AuthLevelValue%%",
+                    "triggerType": "httpTrigger",
+                    "setting": "authLevel"
+                },
+                {
+                    "placeholder": "%%route%%",
+                    "triggerType": "httpTrigger",
+                    "setting": "route"
                 }
             ],
             "actions": [


### PR DESCRIPTION
This approach would enable placeholders to be referenced outside of their bindings; ex. one function with output to queue %%FOO%% and another function with input from queue %%FOO%%.